### PR TITLE
GPS guided bomb patch

### DIFF
--- a/common/units/equipment/modules/00_plane_modules.txt
+++ b/common/units/equipment/modules/00_plane_modules.txt
@@ -1479,18 +1479,31 @@ equipment_modules = {
 		allow_mission_type = {
 			cas
 			attack_logistics
-			#strategic_bomber
+			strategic_bomber
 			port_strike
 		}
 		mission_type_stats = {
 			limit = {
 				cas
 				attack_logistics
-				port_strike
 			}
 			add_stats = {
 				air_ground_attack = 20
 				weight = 0
+			}
+			
+		}
+		mission_type_stats = {
+			limit = {
+				naval_bomber
+				port_strike
+			}
+			add_stats = {
+				naval_strike_attack = 12
+				weight = 0
+			}
+			add_average_stats = {
+				naval_strike_targetting = 10
 			}
 		}
 		# mission_type_stats = {
@@ -1519,18 +1532,31 @@ equipment_modules = {
 		allow_mission_type = {
 			cas
 			attack_logistics
-			#strategic_bomber
+			strategic_bomber
 			port_strike
 		}
 		mission_type_stats = {
 			limit = {
 				cas
 				attack_logistics
-				port_strike
 			}
 			add_stats = {
 				air_ground_attack = 20
 				weight = 0
+			}
+		}
+		mission_type_stats = {
+			limit = {
+				naval_bomber
+				port_strike
+			}
+			add_stats = {
+				air_agility = -5
+				weight = 4
+				naval_strike_attack = 15
+			}
+			add_average_stats = {
+				naval_strike_targetting = 12
 			}
 		}
 		mission_type_stats = {

--- a/common/units/equipment/modules/00_plane_modules.txt
+++ b/common/units/equipment/modules/00_plane_modules.txt
@@ -1479,7 +1479,7 @@ equipment_modules = {
 		allow_mission_type = {
 			cas
 			attack_logistics
-			strategic_bomber
+			#strategic_bomber
 			port_strike
 		}
 		mission_type_stats = {
@@ -1525,14 +1525,14 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 13
-			air_agility = 0
+			air_agility = -9
 			weight = 6
 		}
 		xp_cost = 2
 		allow_mission_type = {
 			cas
 			attack_logistics
-			strategic_bomber
+			#strategic_bomber
 			port_strike
 		}
 		mission_type_stats = {
@@ -1551,8 +1551,6 @@ equipment_modules = {
 				port_strike
 			}
 			add_stats = {
-				air_agility = -5
-				weight = 4
 				naval_strike_attack = 15
 			}
 			add_average_stats = {

--- a/common/units/equipment/modules/00_plane_modules.txt
+++ b/common/units/equipment/modules/00_plane_modules.txt
@@ -1559,15 +1559,15 @@ equipment_modules = {
 				naval_strike_targetting = 12
 			}
 		}
-		mission_type_stats = {
-			limit = {
-				strategic_bomber
-			}
-			add_stats = {
-				air_bombing = 14
-				weight = 0
-			}
-		}
+		# mission_type_stats = {
+		#	limit = {
+		#		strategic_bomber
+		#	}
+		#	add_stats = {
+		#		air_bombing = 14
+		#		weight = 0
+		#	}
+		# }
 		dismantle_cost_ic = 7
 	}
 	large_bomb_bay = {


### PR DESCRIPTION
I was bored and this was bothering me. Having a seizure leaves one with a decent amount of free time. This should fix it so that both guided bombs have attack against naval, but not as much as dedicated torpedos. The higher tier GPS bomb has better stats but the same agility reduction, reflecting that it's essentially the same bomb with a better guidance package.